### PR TITLE
Fix search highlight CSS template

### DIFF
--- a/src/components/ChatRoom.jsx
+++ b/src/components/ChatRoom.jsx
@@ -135,37 +135,30 @@ const ChatRoom = () => {
   };
 
   
-
-  const searchHighlightStyles = `
-  .search-highlight {git add .
-git commit -m "Simplify auth flow"
-git push origin main
-
-
-
-    background-color: #FFE082 !important;
-    box-shadow: 0 0 12px rgba(251, 191, 36, 0.4) !important;
-    transform: scale(1.02);
-    z-index: 1;
-    transition: all 0.5s ease-out !important;
-  }
-  .dark .search-highlight {
-    background-color: #FFA000 !important;
-    box-shadow: 0 0 12px rgba(251, 191, 36, 0.5) !important;
-    transition: all 0.5s ease-out !important;
-  }
-  .search-highlight-dark {
-    background-color: #4CAF50 !important;
-    box-shadow: 0 0 12px rgba(76, 175, 80, 0.4) !important;
-    transform: scale(1.02);
-    z-index: 1;
-    transition: all 0.5s ease-out !important;
-  }
-  .dark .search-highlight-dark {
-    background-color: #2E7D32 !important;
-    box-shadow: 0 0 12px rgba(76, 175, 80, 0.5) !important;
-    transition: all 0.5s ease-out !important;
-  }
+  const searchHighlightStyles = `.search-highlight {
+  background-color: #FFE082 !important;
+  box-shadow: 0 0 12px rgba(251, 191, 36, 0.4) !important;
+  transform: scale(1.02);
+  z-index: 1;
+  transition: all 0.5s ease-out !important;
+}
+.dark .search-highlight {
+  background-color: #FFA000 !important;
+  box-shadow: 0 0 12px rgba(251, 191, 36, 0.5) !important;
+  transition: all 0.5s ease-out !important;
+}
+.search-highlight-dark {
+  background-color: #4CAF50 !important;
+  box-shadow: 0 0 12px rgba(76, 175, 80, 0.4) !important;
+  transform: scale(1.02);
+  z-index: 1;
+  transition: all 0.5s ease-out !important;
+}
+.dark .search-highlight-dark {
+  background-color: #2E7D32 !important;
+  box-shadow: 0 0 12px rgba(76, 175, 80, 0.5) !important;
+  transition: all 0.5s ease-out !important;
+}
 `;
 
 const location = useLocation();


### PR DESCRIPTION
## Summary
- remove stray git commands from search highlight styles in `ChatRoom.jsx`
- ensure CSS template starts with `.search-highlight` rules

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext' with flat config)*

------
https://chatgpt.com/codex/tasks/task_e_6896afaee7f88328b437e158e72313d3