### PR TITLE
Improve push notification error handling

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -234,11 +234,12 @@ app.post('/simpleNotification', async (req, res) => {
       
       // Provide more detailed error information
       let errorMessage = fcmError.message;
-      
+      const errorCode = fcmError.code || fcmError.errorInfo?.code;
+
       // Handle common FCM errors
-      if (fcmError.code === 'messaging/invalid-registration-token') {
+      if (errorCode === 'messaging/invalid-registration-token') {
         errorMessage = 'Invalid FCM token';
-        
+
         // Update the user document to clear the invalid token
         try {
           await admin.firestore().collection('users').doc(userId).update({
@@ -248,9 +249,9 @@ app.post('/simpleNotification', async (req, res) => {
         } catch (updateError) {
           console.error('Error clearing invalid token:', updateError);
         }
-      } else if (fcmError.code === 'messaging/registration-token-not-registered') {
+      } else if (errorCode === 'messaging/registration-token-not-registered') {
         errorMessage = 'FCM token is no longer registered';
-        
+
         // Update the user document to clear the unregistered token
         try {
           await admin.firestore().collection('users').doc(userId).update({
@@ -261,7 +262,7 @@ app.post('/simpleNotification', async (req, res) => {
           console.error('Error clearing unregistered token:', updateError);
         }
       }
-      
+
       return res.json({ success: false, error: errorMessage });
     }
   } catch (error) {

--- a/src/utils/Notifications.js
+++ b/src/utils/Notifications.js
@@ -22,22 +22,33 @@ export const sendNotification = async (userId, notificationData) => {
     
     // Make a preliminary check to see if the user exists
     try {
-      const userCheckResponse = await fetch(`https://us-central1-timetalk-13a75.cloudfunctions.net/api/checkUser`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${idToken}`
-        },
-        body: JSON.stringify({ userId })
-      });
-      
-      const userCheckResult = await userCheckResponse.json();
-      if (!userCheckResult.exists) {
-        console.error(`User ${userId} does not exist in the database`);
-        return { success: false, error: 'User not found' };
+      const userCheckResponse = await fetch(
+        `https://us-central1-timetalk-13a75.cloudfunctions.net/api/checkUser`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${idToken}`
+          },
+          body: JSON.stringify({ userId })
+        }
+      );
+
+      if (userCheckResponse.ok) {
+        const userCheckResult = await userCheckResponse.json();
+        if (!userCheckResult.exists) {
+          console.error(`User ${userId} does not exist in the database`);
+          return { success: false, error: 'User not found' };
+        }
+      } else {
+        // Avoid JSON parsing of HTML error pages
+        console.warn(
+          `User check endpoint responded with ${userCheckResponse.status}`
+        );
       }
     } catch (checkError) {
-      // If the checkUser endpoint doesn't exist, continue with the notification attempt
+      // If the checkUser endpoint doesn't exist or returns invalid JSON,
+      // continue with the notification attempt
       console.warn('User check failed, attempting notification anyway:', checkError);
     }
     


### PR DESCRIPTION
## Summary
- avoid JSON parsing when checkUser endpoint fails
- report Firebase Cloud Messaging error codes and clear invalid tokens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 278 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6896b5cba188832887b7c98ee102ca80