### PR TITLE
Ensure service worker activation before FCM token requests

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -93,6 +93,19 @@ export const refreshFCMToken = async () => {
           updateViaCache: 'none'
         });
 
+        // Wait for the newly registered service worker to become active
+        if (registration.installing) {
+          await new Promise((resolve) => {
+            registration.installing.addEventListener('statechange', (e) => {
+              if (e.target.state === 'activated') {
+                resolve();
+              }
+            });
+          });
+        } else if (!registration.active) {
+          await navigator.serviceWorker.ready;
+        }
+
         // Ensure we have a valid VAPID key before requesting a token
         if (!VAPID_KEY) {
           throw new Error('VAPID key is not defined');

--- a/src/hooks/useNotifications.js
+++ b/src/hooks/useNotifications.js
@@ -48,6 +48,19 @@ export const useNotifications = () => {
                 updateViaCache: 'none'
             });
 
+            // Wait until the service worker is active before requesting a token
+            if (registration.installing) {
+                await new Promise((resolve) => {
+                    registration.installing.addEventListener('statechange', (e) => {
+                        if (e.target.state === 'activated') {
+                            resolve();
+                        }
+                    });
+                });
+            } else if (!registration.active) {
+                await navigator.serviceWorker.ready;
+            }
+
             // Get FCM token
             const token = await getToken(messaging, {
                 vapidKey: 'BJ9j4bdUtNCIQtWDls0PqGtSoGW__yJSv4JZSOXzkuKTizgWLsmYC1t4OxiYx4lrpbcNGm1IUobk_8dGLwvycc',


### PR DESCRIPTION
## Summary
- Wait for service worker to activate before requesting FCM token in `useNotifications` hook.
- Apply same activation check in `refreshFCMToken` to avoid premature token requests.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 269 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6897b0067d94832890d12031de753dd9