### PR TITLE
Refactor service worker registration

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,49 +19,6 @@
     <!-- Web App Manifest -->
     <link rel="manifest" href="/manifest.json">
 
-    <!-- Service Worker Registration -->
-    <script>
-        if ('serviceWorker' in navigator) {
-            window.addEventListener('load', async function() {
-                try {
-                    // Unregister any existing service workers first
-                    const registrations = await navigator.serviceWorker.getRegistrations();
-                    for(let registration of registrations) {
-                        await registration.unregister();
-                    }
-
-                    // Register the new service worker
-                    const registration = await navigator.serviceWorker.register('/firebase-messaging-sw.js', {
-                        scope: '/',
-                        updateViaCache: 'none'
-                    });
-                    
-                    console.log('ServiceWorker registration successful:', registration);
-
-                    // Force update
-                    registration.update();
-
-                    // Handle updates
-                    registration.addEventListener('updatefound', () => {
-                        const newWorker = registration.installing;
-                        console.log('Service Worker update found!');
-                        newWorker.addEventListener('statechange', () => {
-                            console.log('Service Worker state:', newWorker.state);
-                        });
-                    });
-
-                } catch (error) {
-                    console.error('ServiceWorker registration failed:', error);
-                }
-            });
-
-            // Listen for controller change
-            navigator.serviceWorker.addEventListener('controllerchange', () => {
-                console.log('Service Worker controller changed');
-            });
-        }
-    </script>
-
     <!-- iOS PWA notification support -->
     <script>
         // iOS PWA notification support

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -78,20 +78,8 @@ export const refreshFCMToken = async () => {
       
       // Get a fresh token
       try {
-        // Unregister existing service workers first
-        const registrations = await navigator.serviceWorker.getRegistrations();
-        for (let registration of registrations) {
-          if (registration.scope.includes(window.location.origin)) {
-            await registration.unregister();
-            console.log('Unregistered existing service worker');
-          }
-        }
-
-        // Register a new service worker
-        const registration = await navigator.serviceWorker.register('/firebase-messaging-sw.js', {
-          scope: '/',
-          updateViaCache: 'none'
-        });
+        // Use the existing service worker registration
+        const registration = await navigator.serviceWorker.ready;
 
         // Ensure we have a valid VAPID key before requesting a token
         if (!VAPID_KEY) {
@@ -153,28 +141,10 @@ export const requestNotificationPermission = async () => {
         }
       }
       
-      // Step 3: Register service worker (ensuring it's registration is fresh)
+      // Step 3: Use existing service worker registration
       let registration;
       try {
-        // Force update the service worker to ensure latest version
-        registration = await navigator.serviceWorker.register('/firebase-messaging-sw.js', {
-          scope: '/',
-          updateViaCache: 'none'
-        });
-        console.log('Service Worker registered successfully:', registration.scope);
-        
-        // Wait for the registration to activate if needed
-        if (registration.installing) {
-          console.log('Service worker installing...');
-          await new Promise(resolve => {
-            registration.installing.addEventListener('statechange', e => {
-              if (e.target.state === 'activated') {
-                console.log('Service worker activated!');
-                resolve();
-              }
-            });
-          });
-        }
+        registration = await navigator.serviceWorker.ready;
       } catch (err) {
         console.error('Service worker registration failed:', err);
         return null;

--- a/src/hooks/useNotifications.js
+++ b/src/hooks/useNotifications.js
@@ -41,12 +41,9 @@ export const useNotifications = () => {
                 throw new Error('PERMISSION_DENIED');
             }
 
-            // Initialize messaging and get registration
+            // Initialize messaging and get existing registration
             const messaging = getMessaging();
-            const registration = await navigator.serviceWorker.register('/firebase-messaging-sw.js', {
-                scope: '/',
-                updateViaCache: 'none'
-            });
+            const registration = await navigator.serviceWorker.ready;
 
             // Get FCM token
             const token = await getToken(messaging, {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
+import './swRegistration';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/src/swRegistration.js
+++ b/src/swRegistration.js
@@ -1,0 +1,34 @@
+let serviceWorkerRegistration;
+
+if ('serviceWorker' in navigator) {
+  // Immediately register and keep the promise for reuse
+  serviceWorkerRegistration = (async () => {
+    // Ensure only one service worker controls this scope
+    const existing = await navigator.serviceWorker.getRegistration('/');
+    if (existing) {
+      return existing;
+    }
+
+    const registration = await navigator.serviceWorker.register('/firebase-messaging-sw.js', {
+      scope: '/',
+      updateViaCache: 'none'
+    });
+
+    registration.update();
+
+    registration.addEventListener('updatefound', () => {
+      const newWorker = registration.installing;
+      if (newWorker) {
+        newWorker.addEventListener('statechange', () => {
+          console.log('Service Worker state:', newWorker.state);
+        });
+      }
+    });
+
+    return registration;
+  })();
+} else {
+  serviceWorkerRegistration = Promise.resolve(null);
+}
+
+export default serviceWorkerRegistration;


### PR DESCRIPTION
## Summary
- centralize service worker registration in a dedicated module and load it from the app entry point
- remove inline service worker registration from `index.html`
- reuse the shared registration in notification utilities via `navigator.serviceWorker.ready`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 278 problems)

------
https://chatgpt.com/codex/tasks/task_e_6897b00a502483288242c4a622294f78