### PR TITLE
feat: redesign bottom navigation bar

### DIFF
--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -1,78 +1,57 @@
 import React from 'react';
-import { Home, MessageSquare, Calendar, User } from 'lucide-react';
+import { Home, MessageCircle, Calendar, User } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { useDarkMode } from '../context/DarkModeContext';
 
+/**
+ * Bottom navigation bar inspired by provided JSON specification.
+ * - pill shaped container with blur and shadow
+ * - icon only tabs with active/inactive states
+ * - safe area inset support
+ */
 export default function Navigation({ currentPage, setCurrentPage }) {
   const { darkMode } = useDarkMode();
-  const [isKeyboardVisible, setIsKeyboardVisible] = React.useState(false);
 
-  React.useEffect(() => {
-    const handleResize = () => {
-      const isKeyboard = window.innerHeight < window.outerHeight * 0.75;
-      setIsKeyboardVisible(isKeyboard);
-    };
-
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
-
+  // tabs configuration matching routes used in MainApp
   const tabs = [
-    { id: 'home', icon: Home },
-    { id: 'chat', icon: MessageSquare },
-    { id: 'calendar', icon: Calendar },
-    { id: 'profile', icon: User }
+    { id: 'home', icon: Home, label: 'Home' },
+    { id: 'chat', icon: MessageCircle, label: 'Chat', badge: false },
+    { id: 'calendar', icon: Calendar, label: 'Calendar' },
+    { id: 'profile', icon: User, label: 'Profile' }
   ];
 
-  const buttonClasses = (page) => `
-    relative flex-1 flex flex-col items-center justify-center py-3
-    transition-all duration-300 ease-out group
-    ${currentPage === page ? 'text-brand-500' : darkMode ? 'text-gray-400 hover:text-gray-200' : 'text-gray-400 hover:text-gray-600'}
-  `;
+  const handleSelect = (id) => {
+    setCurrentPage(id);
+  };
 
   return (
-    <nav className={`fixed bottom-0 left-0 right-0 z-50 transition-transform duration-300 ${
-      isKeyboardVisible ? 'translate-y-full' : 'translate-y-0'
-    }`}>
-      <div className={`${
-        darkMode
-          ? 'bg-dark-800/80 border-dark-700'
-          : 'bg-white/80 border-brand-100'
-        } backdrop-blur-lg border-t`}>
-        <div className="relative max-w-lg mx-auto flex items-center justify-between px-8">
-          {tabs.map(({ id, icon: Icon }) => (
-            <motion.button
-              key={id}
-              onClick={() => setCurrentPage(id)}
-              className={buttonClasses(id)}
-              whileTap={{ scale: 0.9 }}
-              animate={{ scale: currentPage === id ? 1.1 : 1 }}
-              transition={{ type: 'spring', stiffness: 400, damping: 20 }}
-            >
-              {currentPage === id && (
-                <motion.span
-                  layoutId="nav-active"
-                  className="absolute inset-0 rounded-full bg-brand-100 dark:bg-dark-700"
-                  transition={{ type: 'spring', stiffness: 500, damping: 30 }}
-                />
-              )}
-              <Icon
-                size={24}
-                className={`relative z-10 transition-colors duration-300 ${
-                  currentPage === id
-                    ? 'stroke-2'
-                    : `group-hover:${darkMode ? 'text-gray-200' : 'text-gray-600'}`
-                }`}
-              />
-            </motion.button>
-          ))}
-        </div>
+    <nav className="fixed inset-x-5 bottom-5 z-50">
+      <div
+        className="h-[72px] p-[14px] rounded-[28px] flex items-center justify-between shadow-[0_8px_22px_rgba(0,0,0,0.35)] backdrop-blur-xl"
+        style={{
+          backgroundColor: darkMode ? '#0F1113' : '#111315'
+        }}
+      >
+        {tabs.map(({ id, icon: Icon, label, badge }) => (
+          <motion.button
+            key={id}
+            onClick={() => handleSelect(id)}
+            whileTap={{ scale: 0.9 }}
+            className="relative flex-1 flex items-center justify-center"
+            aria-label={label}
+          >
+            <Icon
+              size={24}
+              className={currentPage === id ? 'text-white' : 'text-[#9AA0A6]'}
+              strokeWidth={currentPage === id ? 2.5 : 2}
+            />
+            {badge && (
+              <span className="absolute top-2 right-3 w-2 h-2 rounded-full bg-[#FF3B30]" />
+            )}
+          </motion.button>
+        ))}
       </div>
-      <div className={`h-[env(safe-area-inset-bottom)] ${
-        darkMode
-          ? 'bg-gray-900/80'
-          : 'bg-white/80'
-        } backdrop-blur-lg`} />
+      <div className="h-[env(safe-area-inset-bottom)]" />
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
- restyle bottom navigation into floating pill with modern colors
- support icon-only tabs and safe area spacing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689900e5aaf883289534454ba212a786