### PR TITLE
feat: add standalone chat demo

### DIFF
--- a/standalone/app.js
+++ b/standalone/app.js
@@ -1,0 +1,249 @@
+// Simple chat demo in vanilla JS
+// Sample messages with mixed content
+const messages = [
+  { id: 1, sender: 'them', text: 'Hey there 👋', time: new Date(Date.now() - 1000*60*60*24*2 + 1000*60*3), status: 'read' },
+  { id: 2, sender: 'me', text: 'Hi! How are you?', time: new Date(Date.now() - 1000*60*60*24*2 + 1000*60*5), status: 'read' },
+  { id: 3, sender: 'them', text: 'Check this out', attachments: [{ type:'image', src:'assets/sample-image.svg' }], time: new Date(Date.now() - 1000*60*60*24 + 1000*60*2), status:'delivered' },
+  { id: 4, sender: 'me', text: 'Looks great!', time: new Date(Date.now() - 1000*60*60*24 + 1000*60*4), status:'sent', replyTo:3 },
+  { id: 5, sender: 'them', text: 'Here is a file', attachments:[{ type:'file', name:'report.pdf', size:'120KB' }], time:new Date(Date.now() - 1000*60*60*24 + 1000*60*6), status:'read', reactions:[{emoji:'❤️',count:1}] },
+  { id: 6, sender: 'me', text: 'Check https://example.com', link:{ title:'Example', description:'Example description', image:'assets/sample-image.svg', url:'https://example.com' }, time:new Date(Date.now() - 1000*60*30), status:'read' },
+  { id: 7, sender: 'them', text: 'Nice link!', time:new Date(Date.now() - 1000*60*25), status:'read' },
+  { id: 8, sender: 'me', text: 'Another message', time:new Date(Date.now() - 1000*60*5), status:'sent' },
+  { id: 9, sender: 'them', text: 'Last one for now', time:new Date(Date.now() - 1000*60*2), status:'sent' }
+];
+
+let unreadIndex = 5; // position where unread divider appears
+let replyingTo = null;
+let editing = null;
+
+// Element refs
+const messageList = document.getElementById('messageList');
+const sendBtn = document.getElementById('sendBtn');
+const composerInput = document.getElementById('composerInput');
+const scrollFab = document.getElementById('scrollFab');
+const unreadBadge = document.getElementById('unreadBadge');
+const typingIndicator = document.getElementById('typingIndicator');
+const replyBar = document.getElementById('replyBar');
+const connectivity = document.getElementById('connectivity');
+const overflowMenu = document.getElementById('overflowMenu');
+const menuBtn = document.getElementById('menuBtn');
+const actionSheet = document.getElementById('actionSheet');
+
+// Render skeleton first
+messageList.innerHTML = '<div class="skeleton"></div><div class="skeleton"></div><div class="skeleton"></div>';
+setTimeout(renderMessages, 600);
+
+function groupByDay(msgs) {
+  return msgs.reduce((acc,m)=>{
+    const day = formatDay(m.time);
+    acc[day] = acc[day] || [];
+    acc[day].push(m);
+    return acc;
+  },{});
+}
+
+function formatDay(date){
+  const today = new Date();
+  const d = new Date(date);
+  const diff = today.setHours(0,0,0,0) - d.setHours(0,0,0,0);
+  if(diff===0) return 'Today';
+  if(diff===86400000) return 'Yesterday';
+  return d.toLocaleDateString(undefined,{month:'short',day:'numeric'});
+}
+function formatTime(date){
+  return new Date(date).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'});
+}
+
+function renderMessages(){
+  messageList.innerHTML = '';
+  const groups = groupByDay(messages);
+  let index = 0;
+  Object.keys(groups).sort((a,b)=> new Date(groups[a][0].time) - new Date(groups[b][0].time)).forEach(day=>{
+    const header = document.createElement('div');
+    header.className='time-header';
+    header.textContent = day;
+    messageList.appendChild(header);
+    groups[day].forEach((m)=>{
+      if(index===unreadIndex){
+        const divider=document.createElement('div');
+        divider.className='unread-divider';
+        divider.innerHTML='<span>New</span>';
+        messageList.appendChild(divider);
+      }
+      const el = buildMessage(m, index);
+      messageList.appendChild(el);
+      index++;
+    });
+  });
+  const unreadCount = messages.length - unreadIndex;
+  unreadBadge.textContent = unreadCount;
+  unreadBadge.classList.toggle("hidden", unreadCount <= 0);
+  scrollToBottom();
+}
+
+function buildMessage(m, index){
+  const div=document.createElement('div');
+  div.className=`msg ${m.sender}`;
+  // tail logic
+  const next=messages[index+1];
+  if(!next || next.sender!==m.sender) div.classList.add('tail');
+
+  // long press handler
+  div.addEventListener('contextmenu',e=>{e.preventDefault();openActionSheet(m);});
+
+  // reply preview
+  if(m.replyTo){
+    const original=messages.find(x=>x.id===m.replyTo);
+    if(original){
+      const reply=document.createElement('div');
+      reply.className='reply';
+      reply.textContent = original.text.slice(0,40);
+      div.appendChild(reply);
+    }
+  }
+  // text content
+  if(m.text){
+    const span=document.createElement('span');
+    span.textContent=m.text;
+    div.appendChild(span);
+  }
+  // attachments
+  if(m.attachments){
+    const cont=document.createElement('div');
+    cont.className='attachments';
+    m.attachments.forEach(att=>{
+      if(att.type==='image'){
+        const img=document.createElement('img');
+        img.src=att.src; img.alt='';
+        img.style.maxWidth='100%';
+        img.style.borderRadius='12px';
+        img.addEventListener('click',()=>openMediaViewer(att.src));
+        cont.appendChild(img);
+      } else if(att.type==='file'){
+        const card=document.createElement('div');
+        card.className='file-card';
+        card.innerHTML=`<strong>${att.name}</strong><br><small>${att.size}</small>`;
+        cont.appendChild(card);
+      }
+    });
+    div.appendChild(cont);
+  }
+  // link preview
+  if(m.link){
+    const a=document.createElement('a');
+    a.href=m.link.url; a.target='_blank'; a.className='link-card';
+    a.innerHTML=`<img src="${m.link.image}" alt=""/><div><strong>${m.link.title}</strong><p>${m.link.description}</p></div>`;
+    div.appendChild(a);
+  }
+  // meta row
+  const meta=document.createElement('div');
+  meta.className='meta';
+  const time=document.createElement('span');
+  time.textContent=formatTime(m.time);
+  meta.appendChild(time);
+  const state=document.createElement('span');
+  state.innerHTML=statusIcon(m.status);
+  meta.appendChild(state);
+  div.appendChild(meta);
+
+  // reactions
+  if(m.reactions){
+    const rs=document.createElement('div'); rs.className='reactions';
+    m.reactions.forEach(r=>{
+      const pill=document.createElement('span'); pill.className='reaction'; pill.textContent=`${r.emoji} ${r.count}`;
+      rs.appendChild(pill);
+    });
+    div.appendChild(rs);
+  }
+  return div;
+}
+
+function statusIcon(state){
+  switch(state){
+    case 'sending': return '⏱';
+    case 'sent': return '✓';
+    case 'delivered': return '✓✓';
+    case 'read': return '<span style="color:var(--success)">✓✓</span>';
+    default: return '';
+  }
+}
+
+function appendMessage(text){
+  if(editing){ editing.text=text; editing=null; replyBar.classList.add('hidden'); renderMessages(); return; }
+  const msg={ id:Date.now(), sender:'me', text, time:new Date(), status:'sent' };
+  if(replyingTo){ msg.replyTo=replyingTo.id; replyingTo=null; replyBar.classList.add('hidden'); }
+  messages.push(msg);
+  renderMessages();
+}
+
+function scrollToBottom(){
+  requestAnimationFrame(()=>{ messageList.scrollTop = messageList.scrollHeight; });
+}
+
+// Typing indicator
+function setTyping(v){ typingIndicator.classList.toggle('hidden', !v); }
+// Connectivity banner
+function setConnectivity(v){ connectivity.classList.toggle('hidden', v); }
+// Theme toggle
+function toggleTheme(){ document.documentElement.classList.toggle('theme-dark'); }
+function openMediaViewer(src){ alert('Open media: '+src); }
+
+// Overflow menu toggle
+menuBtn.addEventListener('click',()=> overflowMenu.classList.toggle('hidden') );
+overflowMenu.addEventListener('click',e=>{
+  const action=e.target.dataset.action;
+  if(!action) return;
+  overflowMenu.classList.add('hidden');
+  if(action==='theme') toggleTheme();
+});
+
+// Composer logic
+composerInput.addEventListener('input',()=>{
+  composerInput.style.height='auto';
+  composerInput.style.height=Math.min(composerInput.scrollHeight,120)+"px";
+  sendBtn.disabled=!composerInput.value.trim();
+});
+
+sendBtn.addEventListener('click',()=>{
+  const text=composerInput.value.trim();
+  if(!text) return;
+  appendMessage(text);
+  composerInput.value='';
+  composerInput.dispatchEvent(new Event('input'));
+});
+
+// Scroll fab visibility
+messageList.addEventListener('scroll',()=>{
+  const nearBottom = messageList.scrollHeight - messageList.scrollTop - messageList.clientHeight < 50;
+  scrollFab.classList.toggle('hidden', nearBottom);
+});
+scrollFab.addEventListener('click',scrollToBottom);
+
+// Action sheet for message
+function openActionSheet(msg){
+  actionSheet.classList.remove('hidden');
+  actionSheet.onclick=(e)=>{
+    if(e.target.dataset.action==='reply'){
+      replyingTo=msg; replyBar.textContent='Replying to: '+msg.text; replyBar.classList.remove('hidden');
+    } else if(e.target.dataset.action==='edit'){
+      editing=msg; composerInput.value=msg.text; composerInput.focus(); sendBtn.disabled=false; replyBar.textContent='Editing message'; replyBar.classList.remove('hidden');
+    } else if(e.target.dataset.action==='copy'){
+      navigator.clipboard?.writeText(msg.text||'');
+    } else if(e.target.dataset.action==='delete'){
+      const idx=messages.indexOf(msg); if(idx>-1){ messages.splice(idx,1); renderMessages(); }
+    } else if(e.target.dataset.action==='react'){
+      msg.reactions = msg.reactions || []; msg.reactions.push({emoji:'👍',count:1}); renderMessages();
+    }
+    actionSheet.classList.add('hidden');
+  };
+  actionSheet.querySelector('.sheet-backdrop').onclick=()=> actionSheet.classList.add('hidden');
+}
+
+// Reply bar cancel
+replyBar.addEventListener('click',()=>{ replyingTo=null; editing=null; replyBar.classList.add('hidden'); });
+
+// Typing & connectivity demo toggles
+window.setTyping = setTyping;
+window.setConnectivity = setConnectivity;
+window.toggleTheme = toggleTheme;
+

--- a/standalone/assets/avatar-partner.svg
+++ b/standalone/assets/avatar-partner.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="32" fill="#0ea5e9"/>
+  <text x="32" y="37" font-size="32" text-anchor="middle" fill="#fff" font-family="sans-serif">P</text>
+</svg>

--- a/standalone/assets/avatar-user.svg
+++ b/standalone/assets/avatar-user.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="32" fill="#7c3aed"/>
+  <text x="32" y="37" font-size="32" text-anchor="middle" fill="#fff" font-family="sans-serif">U</text>
+</svg>

--- a/standalone/assets/empty.svg
+++ b/standalone/assets/empty.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <rect width="120" height="120" rx="12" ry="12" fill="#f3f4f6"/>
+  <text x="60" y="65" font-size="24" text-anchor="middle" fill="#9ca3af" font-family="sans-serif">👋</text>
+</svg>

--- a/standalone/assets/sample-image.svg
+++ b/standalone/assets/sample-image.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200">
+  <rect width="300" height="200" fill="#eee"/>
+  <circle cx="150" cy="100" r="60" fill="#e2e8f0"/>
+</svg>

--- a/standalone/index.html
+++ b/standalone/index.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en" class="theme-light">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <title>Chat Demo</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <!-- Connectivity banner -->
+  <div id="connectivity" class="connectivity hidden" role="status">You're offline. Sending when back online.</div>
+
+  <!-- Top app bar -->
+  <header class="app-bar" role="banner">
+    <button class="icon-btn" aria-label="Back">
+      <svg viewBox="0 0 24 24" width="24" height="24"><path d="M15 18l-6-6 6-6" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/></svg>
+    </button>
+    <div class="partner">
+      <img src="assets/avatar-partner.svg" alt="Partner" class="avatar" />
+      <div class="partner-info">
+        <div class="partner-name">Partner</div>
+        <div class="partner-status" id="partnerStatus">Online</div>
+      </div>
+    </div>
+    <div class="actions">
+      <button class="icon-btn" aria-label="Search">
+        <svg viewBox="0 0 24 24" width="24" height="24"><circle cx="11" cy="11" r="7" stroke="currentColor" stroke-width="2" fill="none"/><path d="m16 16 5 5" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/></svg>
+      </button>
+      <button class="icon-btn" aria-label="Call">
+        <svg viewBox="0 0 24 24" width="24" height="24"><path d="M22 16.92v3a2 2 0 0 1-2.18 2A19.79 19.79 0 0 1 3.11 5.18 2 2 0 0 1 5.11 3h3a2 2 0 0 1 2 1.72c.12.81.37 1.6.72 2.34a2 2 0 0 1-.45 2.11L9.91 9.91a16 16 0 0 0 6.18 6.18l.74-.74a2 2 0 0 1 2.11-.45c.74.35 1.53.6 2.34.72A2 2 0 0 1 22 16.92z" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </button>
+      <button id="menuBtn" class="icon-btn" aria-label="More">
+        <svg viewBox="0 0 24 24" width="24" height="24"><circle cx="12" cy="12" r="1"/><circle cx="12" cy="5" r="1"/><circle cx="12" cy="19" r="1"/></svg>
+      </button>
+      <!-- Overflow menu -->
+      <div id="overflowMenu" class="menu hidden" role="menu">
+        <button data-action="mute">Mute</button>
+        <button data-action="block">Block</button>
+        <button data-action="clear">Clear chat</button>
+        <button data-action="export">Export</button>
+        <button data-action="theme">Toggle theme</button>
+      </div>
+    </div>
+  </header>
+
+  <!-- Message list -->
+  <main id="messageList" class="message-list" role="main" aria-live="polite"></main>
+
+  <!-- Typing indicator -->
+  <div id="typingIndicator" class="typing hidden">
+    <div class="dot"></div><div class="dot"></div><div class="dot"></div>
+  </div>
+
+  <!-- Scroll to bottom FAB -->
+  <button id="scrollFab" class="fab hidden" aria-label="Scroll to bottom">
+    <svg viewBox="0 0 24 24" width="24" height="24"><path d="M12 5v14M5 12l7 7 7-7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/></svg>
+    <span id="unreadBadge" class="badge hidden"></span>
+  </button>
+
+  <!-- Composer -->
+  <div id="replyBar" class="reply-bar hidden" role="status"></div>
+  <div class="composer" role="form">
+    <div class="composer-inner">
+      <div class="composer-left">
+        <button class="icon-btn" id="attachBtn" aria-label="Add">
+          <svg viewBox="0 0 24 24" width="24" height="24"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/></svg>
+        </button>
+        <button class="icon-btn" id="emojiBtn" aria-label="Emoji">
+          <svg viewBox="0 0 24 24" width="24" height="24"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="none"/><path d="M8 15c1.333 1 2.667 1 4 0 1.333 1 2.667 1 4 0" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/><path d="M9 9h.01M15 9h.01" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+        </button>
+      </div>
+      <textarea id="composerInput" class="composer-input" placeholder="Message" rows="1" aria-label="Message"></textarea>
+      <div class="composer-right">
+        <button class="icon-btn" id="micBtn" aria-label="Record">
+          <svg viewBox="0 0 24 24" width="24" height="24"><rect x="9" y="2" width="6" height="12" rx="3"/><path d="M5 10v2a7 7 0 0 0 14 0v-2" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/><line x1="12" y1="19" x2="12" y2="22" stroke="currentColor" stroke-width="2"/></svg>
+        </button>
+        <button class="icon-btn" id="sendBtn" aria-label="Send" disabled>
+          <svg viewBox="0 0 24 24" width="24" height="24"><path d="m22 2-7 20-4-9-9-4Z" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Bottom navigation -->
+  <nav class="bottom-nav" role="navigation">
+    <button class="nav-btn" aria-label="Home">
+      <svg viewBox="0 0 24 24" width="24" height="24"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      <span>Home</span>
+    </button>
+    <button class="nav-btn active" aria-current="page" aria-label="Chat">
+      <svg viewBox="0 0 24 24" width="24" height="24"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2Z" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      <span>Chat</span>
+    </button>
+    <button class="nav-btn" aria-label="Calendar">
+      <svg viewBox="0 0 24 24" width="24" height="24"><rect x="3" y="4" width="18" height="18" rx="2" ry="2" stroke="currentColor" stroke-width="2" fill="none"/><path d="M16 2v4M8 2v4M3 10h18" stroke="currentColor" stroke-width="2"/></svg>
+      <span>Calendar</span>
+    </button>
+    <button class="nav-btn" aria-label="Profile">
+      <svg viewBox="0 0 24 24" width="24" height="24"><circle cx="12" cy="7" r="4"/><path d="M5.5 21a8.38 8.38 0 0 1 13 0"/></svg>
+      <span>Profile</span>
+    </button>
+  
+</nav>
+
+  <div id="actionSheet" class="action-sheet hidden">
+    <div class="sheet-backdrop"></div>
+    <div class="sheet">
+      <button data-action="reply">Reply</button>
+      <button data-action="copy">Copy</button>
+      <button data-action="react">React</button>
+      <button data-action="edit">Edit</button>
+      <button data-action="delete">Delete</button>
+    </div>
+  </div>
+
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/standalone/styles.css
+++ b/standalone/styles.css
@@ -1,0 +1,128 @@
+/* Theme variables */
+:root {
+  --surface: #ffffff;
+  --surface-2: #f1f5f9;
+  --text: #111827;
+  --text-muted: #6b7280;
+  --accent: #7c3aed;
+  --success: #22c55e;
+  --radius: 20px;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --shadow-md: 0 4px 8px rgba(0,0,0,0.08);
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;
+}
+
+.theme-dark {
+  --surface: #1f2937;
+  --surface-2: #374151;
+  --text: #f9fafb;
+  --text-muted: #9ca3af;
+}
+
+body {
+  margin: 0;
+  background: var(--surface);
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overscroll-behavior: none;
+}
+
+.hidden { display: none; }
+
+/* App bar */
+.app-bar {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: calc(env(safe-area-inset-top) + 4px) 16px 8px;
+  backdrop-filter: blur(12px);
+  background: rgba(255,255,255,.8);
+  box-shadow: var(--shadow-sm);
+  z-index: 10;
+}
+.theme-dark .app-bar { background: rgba(31,41,55,.8); }
+.avatar { width: 32px; height: 32px; border-radius: 50%; }
+.partner { flex: 1; display: flex; align-items: center; gap: 8px; }
+.partner-name { font-weight: 600; }
+.partner-status { font-size: 13px; color: var(--text-muted); }
+.actions { display:flex; align-items:center; position:relative; }
+.menu { position:absolute; top:56px; right:0; background:var(--surface); border-radius:12px; box-shadow:var(--shadow-md); overflow:hidden; }
+.menu button { padding:12px 16px; font-size:15px; background:none; border:none; text-align:left; color:var(--text); width:100%; }
+
+/* Message list */
+.message-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 16px 120px;
+  background: var(--surface);
+}
+.time-header { text-align:center; margin:16px 0; font-size:13px; color:var(--text-muted); }
+.unread-divider { text-align:center; margin:8px 0; position:relative; }
+.unread-divider::before { content:""; position:absolute; top:50%; left:0; right:0; border-top:1px solid var(--surface-2); }
+.unread-divider span { background:var(--surface); padding:0 8px; color:var(--accent); position:relative; font-size:13px; }
+.msg { max-width:78%; padding:6px 10px; border-radius:var(--radius); margin:2px 0; position:relative; display:inline-block; animation:msg-in .2s ease-out; }
+.msg.me { align-self:flex-end; background:var(--accent); color:#fff; }
+.msg.them { align-self:flex-start; background:var(--surface-2); }
+.msg.tail.me { border-bottom-right-radius:4px; }
+.msg.tail.them { border-bottom-left-radius:4px; }
+.meta { display:inline-flex; gap:4px; font-size:13px; color:var(--text-muted); margin-top:2px; }
+.msg.me .meta { color: rgba(255,255,255,.8); }
+.reply { border-left:3px solid var(--accent); padding-left:8px; margin-bottom:4px; font-size:15px; color:var(--text-muted); }
+.reactions { margin-top:4px; display:flex; gap:4px; }
+.reaction { background:var(--surface); border-radius:12px; padding:2px 6px; font-size:13px; box-shadow:var(--shadow-sm); transform:scale(0); animation:react-in .2s forwards; }
+
+/* Typing indicator */
+.typing { position:absolute; bottom:96px; left:16px; display:flex; gap:4px; padding:8px 12px; border-radius:var(--radius); background:var(--surface-2); box-shadow:var(--shadow-sm); }
+.typing .dot { width:6px; height:6px; border-radius:50%; background:var(--text-muted); animation:typing 1.2s infinite; }
+.typing .dot:nth-child(2) { animation-delay:.2s; }
+.typing .dot:nth-child(3) { animation-delay:.4s; }
+
+/* Scroll fab */
+.fab { position:fixed; bottom:120px; right:16px; width:44px; height:44px; border-radius:22px; background:var(--accent); color:#fff; display:flex; align-items:center; justify-content:center; border:none; box-shadow:var(--shadow-md); transition:transform .2s ease; z-index:20; }
+.fab.hidden { transform:scale(0); }
+.badge { position:absolute; top:-4px; right:-4px; background:var(--success); color:#fff; border-radius:12px; padding:0 4px; font-size:12px; }
+
+/* Reply bar */
+.reply-bar { position:fixed; bottom:120px; left:0; right:0; padding:4px 16px; background:var(--surface-2); font-size:15px; color:var(--text); display:flex; justify-content:space-between; align-items:center; box-shadow:var(--shadow-sm); }
+
+/* Composer */
+.composer { position:fixed; bottom:64px; left:0; right:0; padding:8px 16px; padding-bottom:calc(8px + env(safe-area-inset-bottom)); background:var(--surface); box-shadow:var(--shadow-md); }
+.composer-inner { display:flex; align-items:flex-end; gap:8px; }
+.composer-input { flex:1; max-height:120px; overflow-y:auto; border:none; outline:none; border-radius:20px; padding:8px 12px; background:var(--surface-2); resize:none; font-size:17px; }
+.icon-btn { width:44px; height:44px; border:none; background:transparent; color:var(--text); display:flex; align-items:center; justify-content:center; border-radius:50%; transition:background .2s; }
+.icon-btn:active { background:var(--surface-2); }
+
+/* Bottom nav */
+.bottom-nav { position:fixed; bottom:0; left:0; right:0; height:64px; padding-bottom:env(safe-area-inset-bottom); background:var(--surface); display:flex; justify-content:space-around; align-items:center; box-shadow:0 -1px 2px rgba(0,0,0,0.05); }
+.nav-btn { flex:1; background:none; border:none; color:var(--text-muted); display:flex; flex-direction:column; align-items:center; gap:4px; font-size:12px; }
+.nav-btn.active { color:var(--accent); }
+
+/* Animations */
+@keyframes typing { 0%,80%,100% { opacity:.2; } 40% { opacity:1; } }
+@keyframes msg-in { from { transform:translateY(10px); opacity:0; } to { transform:translateY(0); opacity:1; } }
+@keyframes react-in { to { transform:scale(1); } }
+
+/* Action sheet */
+.action-sheet { position:fixed; top:0; left:0; right:0; bottom:0; display:flex; align-items:flex-end; justify-content:center; z-index:30; }
+.sheet-backdrop { position:absolute; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,.3); }
+.sheet { background:var(--surface); width:100%; border-top-left-radius:16px; border-top-right-radius:16px; box-shadow:var(--shadow-md); padding:8px 0; }
+.action-sheet button { width:100%; padding:16px; background:none; border:none; font-size:17px; color:var(--text); }
+
+/* Skeleton loader */
+.skeleton { height:20px; background:var(--surface-2); border-radius:8px; margin:8px 0; animation:pulse 1.5s infinite; }
+@keyframes pulse { 0%,100%{ opacity:.6; } 50%{ opacity:1; } }
+
+.attachments img { display:block; margin-top:4px; }
+.file-card { background:var(--surface); border-radius:12px; padding:8px; font-size:15px; margin-top:4px; box-shadow:var(--shadow-sm); }
+.link-card { display:flex; gap:8px; background:var(--surface); border-radius:12px; text-decoration:none; color:var(--text); overflow:hidden; margin-top:4px; box-shadow:var(--shadow-sm); }
+.link-card img { width:48px; height:48px; object-fit:cover; }
+.link-card div { flex:1; }
+.link-card p { margin:0; font-size:13px; color:var(--text-muted); }
+
+/* Connectivity banner */
+.connectivity { position:fixed; top:0; left:0; right:0; padding:8px; text-align:center; background:#f87171; color:#fff; font-size:15px; z-index:30; }
+.theme-dark .connectivity { background:#b91c1c; }


### PR DESCRIPTION
## Summary
- add a standalone iOS-style chat page with app bar, message list, composer, and bottom navigation
- include CSS variables with dark theme, bubbles, action sheet, skeleton loaders, and connectivity banner
- vanilla JS rendering with sample messages, reactions, replies, theme toggle, and message actions

## Testing
- `npm run lint` *(fails: global is not defined in existing files)*
- `npx eslint standalone`

------
https://chatgpt.com/codex/tasks/task_e_689902f349908328a4538fb714687359