### PR TITLE
Hide nav during iOS keyboard on chat page

### DIFF
--- a/src/components/MainApp.jsx
+++ b/src/components/MainApp.jsx
@@ -36,6 +36,7 @@ const MainApp = () => {
   const [user, setUser] = useState(null);
   const { getPartnerProfile } = useAuth();
   const location = useLocation();
+  const [hideNav, setHideNav] = useState(false);
   useEffect(() => {
     if (location.pathname.startsWith('/chat')) {
       setCurrentPage('chat');
@@ -47,6 +48,12 @@ const MainApp = () => {
       setCurrentPage('home');
     }
   }, [location.pathname]);
+
+  useEffect(() => {
+    if (currentPage !== 'chat') {
+      setHideNav(false);
+    }
+  }, [currentPage]);
 
 
 
@@ -385,7 +392,7 @@ const MainApp = () => {
           ) : currentPage === 'profile' ? (
             <ProfilePage />
           ) : currentPage === 'chat' ? (
-            <ChatRoom />
+            <ChatRoom onKeyboardChange={setHideNav} />
           ) : currentPage === 'calendar' ? (
             <SharedCalendar />
           ) : (
@@ -399,9 +406,12 @@ const MainApp = () => {
         </div>
       </div>
 
-      <div className="fixed bottom-0 left-0 right-0 h-[env(safe-area-inset-bottom)] bg-transparent z-[49]" />
-
-      <Navigation currentPage={currentPage} setCurrentPage={setCurrentPage} />
+      {!hideNav && (
+        <>
+          <div className="fixed bottom-0 left-0 right-0 h-[env(safe-area-inset-bottom)] bg-transparent z-[49]" />
+          <Navigation currentPage={currentPage} setCurrentPage={setCurrentPage} />
+        </>
+      )}
 
       <SecretPostModal 
         isOpen={showSecretModal}


### PR DESCRIPTION
## Summary
- hide bottom nav when chat keyboard opens
- pin chat input above iOS keyboard using visual viewport
- adjust layout using dynamic viewport height to avoid 100vh bug

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: various eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689909bb83e08328834b79a239b9ec37