### PR TITLE
feat: add event-driven store with local storage

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,57 @@
+const DEFAULT_STATE = {
+  posts: [],
+  messages: [],
+  events: [],
+  profile: {},
+};
+
+// Basic localStorage-backed adapter.
+const isBrowser = typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+let storage = {
+  load: () => {
+    if (!isBrowser) return {};
+    try {
+      return JSON.parse(window.localStorage.getItem('timtalk-store') || '{}');
+    } catch {
+      return {};
+    }
+  },
+  save: (data) => {
+    if (!isBrowser) return;
+    window.localStorage.setItem('timtalk-store', JSON.stringify(data));
+  },
+};
+
+let state = { ...DEFAULT_STATE, ...storage.load() };
+const subscribers = {};
+
+function notify(key) {
+  if (!subscribers[key]) return;
+  for (const fn of subscribers[key]) fn(state[key]);
+}
+
+export function get(key) {
+  return state[key];
+}
+
+export function set(key, value) {
+  state[key] = value;
+  storage.save(state);
+  notify(key);
+}
+
+export function update(key, updater) {
+  const value = typeof updater === 'function' ? updater(state[key]) : updater;
+  set(key, value);
+}
+
+export function subscribe(key, fn) {
+  subscribers[key] ||= new Set();
+  subscribers[key].add(fn);
+  return () => subscribers[key].delete(fn);
+}
+
+export function setStorageAdapter(adapter) {
+  storage = adapter;
+  state = { ...DEFAULT_STATE, ...storage.load() };
+}


### PR DESCRIPTION
## Summary
- add simple pub/sub store for posts, messages, events, and profile
- persist state with localStorage and pluggable adapter

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: many lint errors)*
- `npx eslint src/store.js`


------
https://chatgpt.com/codex/tasks/task_e_68990f11555483288d379f0d248830ef