### PR TITLE
Improve chat input visibility and nav behavior

### DIFF
--- a/src/components/MainApp.jsx
+++ b/src/components/MainApp.jsx
@@ -425,7 +425,7 @@ const MainApp = () => {
               ) : currentPage === 'profile' ? (
                 <ProfilePage />
               ) : currentPage === 'chat' ? (
-                <ChatRoom />
+                <ChatRoom setHideNav={setHideNav} hideNav={hideNav} />
               ) : currentPage === 'calendar' ? (
                 <SharedCalendar />
               ) : (


### PR DESCRIPTION
## Summary
- keep latest chat messages visible by padding scroll area based on input bar height
- hide bottom navigation while typing and restore when input loses focus

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 267 problems)


------
https://chatgpt.com/codex/tasks/task_e_6899292cc4408328b04c9ef8e7eedf69