### PR TITLE
style: modern floating bottom navigation

### DIFF
--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -1,6 +1,6 @@
-import React from 'react';
 import { Home, MessageCircle, Calendar, User } from 'lucide-react';
-import { motion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
+import PropTypes from 'prop-types';
 import { useDarkMode } from '../context/DarkModeContext';
 
 /**
@@ -11,12 +11,13 @@ import { useDarkMode } from '../context/DarkModeContext';
  */
 export default function Navigation({ currentPage, setCurrentPage }) {
   const { darkMode } = useDarkMode();
+  const shouldReduceMotion = useReducedMotion();
 
   // tabs configuration matching routes used in MainApp
   const tabs = [
     { id: 'home', icon: Home, label: 'Home' },
-    { id: 'chat', icon: MessageCircle, label: 'Chat', badge: false },
-    { id: 'calendar', icon: Calendar, label: 'Calendar' },
+    { id: 'chat', icon: MessageCircle, label: 'Chat', badge: 0 },
+    { id: 'calendar', icon: Calendar, label: 'Calendar', badge: 0 },
     { id: 'profile', icon: User, label: 'Profile' }
   ];
 
@@ -24,41 +25,81 @@ export default function Navigation({ currentPage, setCurrentPage }) {
     setCurrentPage(id);
   };
 
+  const transition = {
+    duration: shouldReduceMotion ? 0 : 0.2,
+    ease: 'easeOut'
+  };
+
   return (
     <motion.nav
       initial={{ y: 80, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
       exit={{ y: 80, opacity: 0 }}
-      transition={{ duration: 0.2 }}
-      className="fixed inset-x-0 bottom-0 z-40 pb-[env(safe-area-inset-bottom)]"
+      transition={transition}
+      className="fixed inset-x-0 bottom-0 z-50 pb-[env(safe-area-inset-bottom)] pointer-events-none"
     >
       <div
-        className="mx-4 mb-4 flex items-center justify-between rounded-2xl backdrop-blur-md shadow-lg"
+        className="pointer-events-auto mx-auto mb-2 flex max-w-md items-center justify-between rounded-3xl shadow-lg ring-1 ring-black/5 backdrop-blur-xl"
         style={{
           backgroundColor: darkMode
-            ? 'rgba(17,19,21,0.6)'
-            : 'rgba(255,255,255,0.6)'
+            ? 'rgba(24,24,27,0.8)'
+            : 'rgba(255,255,255,0.8)'
         }}
       >
-        {tabs.map(({ id, icon: Icon, label, badge }) => (
-          <motion.button
-            key={id}
-            onClick={() => handleSelect(id)}
-            whileTap={{ scale: 0.95 }}
-            className="relative flex-1 flex items-center justify-center h-14"
-            aria-label={label}
-          >
-            <Icon
-              size={24}
-              className={currentPage === id ? 'text-white' : 'text-[#9AA0A6]'}
-              strokeWidth={currentPage === id ? 2.5 : 2}
-            />
-            {badge && (
-              <span className="absolute top-2 right-3 w-2 h-2 rounded-full bg-[#FF3B30]" />
-            )}
-          </motion.button>
-        ))}
+        {tabs.map(({ id, icon: Icon, label, badge }) => {
+          const active = currentPage === id;
+          return (
+            <motion.button
+              key={id}
+              onClick={() => handleSelect(id)}
+              whileTap={{ scale: 0.98, opacity: 0.8 }}
+              className="relative flex h-14 flex-1 items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2"
+              aria-label={label}
+              aria-current={active ? 'page' : undefined}
+            >
+              <Icon
+                size={24}
+                strokeWidth={active ? 2.5 : 2}
+                className={active ? '' : 'opacity-70'}
+                style={{
+                  color: active
+                    ? 'var(--accent)'
+                    : darkMode
+                      ? 'rgb(156 163 175)'
+                      : 'rgb(107 114 128)',
+                  fill: active ? 'currentColor' : 'none'
+                }}
+              />
+              {active && (
+                <motion.span
+                  layoutId="nav-indicator"
+                  className="pointer-events-none absolute bottom-1 h-1 w-8 rounded-full"
+                  style={{
+                    background: 'linear-gradient(90deg,var(--accent),var(--accent-2))'
+                  }}
+                  transition={transition}
+                />
+              )}
+              {badge > 0 && (
+                <span
+                  className="absolute top-2 right-4 min-w-[0.5rem] rounded-full bg-[var(--accent)] px-1 text-[10px] font-medium text-white"
+                >
+                  {badge > 99 ? '99+' : badge}
+                </span>
+              )}
+              {badge === true && (
+                <span className="absolute top-2 right-4 h-2 w-2 rounded-full bg-[var(--accent)]" />
+              )}
+              <span className="sr-only">{label}</span>
+            </motion.button>
+          );
+        })}
       </div>
     </motion.nav>
   );
 }
+
+Navigation.propTypes = {
+  currentPage: PropTypes.string.isRequired,
+  setCurrentPage: PropTypes.func.isRequired
+};

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,16 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --accent: #8b5cf6;
+  --accent-2: #d946ef;
+}
+
+.dark {
+  --accent: #8b5cf6;
+  --accent-2: #7c3aed;
+}
+
 body {
   @apply bg-gradient-to-br from-brand-50 via-white to-brand-100 dark:from-dark-900 dark:via-dark-800 dark:to-dark-900 text-gray-900 dark:text-gray-100 antialiased;
   font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Inter', sans-serif;


### PR DESCRIPTION
## Summary
- restyle bottom navigation as a floating dock with accent indicator
- expose accent colors via CSS variables for easy theming
- remove tab labels and tighten spacing while keeping accessibility
- ensure profile tab doesn't block interactions by raising nav z-index

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 263 problems)*
- `npx eslint src/components/Navigation.jsx`


------
https://chatgpt.com/codex/tasks/task_e_689956008e20832899c247c44974b001