### PR TITLE
Fix profile page freezing due to duplicated auth hook

### DIFF
--- a/src/components/profile/SpotifySection.jsx
+++ b/src/components/profile/SpotifySection.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useSpotify } from '../../hooks/useSpotify';
 import { useAuth } from '../../hooks/useAuth';
 import { Music, Disc3 } from 'lucide-react';
@@ -72,8 +72,17 @@ const SpotifyPlayer = ({ userId, username }) => {
 };
 
 const SpotifySection = () => {
-  const { user } = useAuth();
-  const { partnerProfile } = useAuth();
+  const { user, getPartnerProfile } = useAuth();
+  const [partnerProfile, setPartnerProfile] = useState(null);
+
+  useEffect(() => {
+    const fetchPartner = async () => {
+      const partner = await getPartnerProfile();
+      setPartnerProfile(partner);
+    };
+
+    fetchPartner();
+  }, [getPartnerProfile]);
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -95,9 +104,9 @@ const SpotifySection = () => {
               {partnerProfile.displayName}'s Music
             </h3>
           </div>
-          <SpotifyPlayer 
-            userId={partnerProfile.uid} 
-            username={partnerProfile.displayName} 
+          <SpotifyPlayer
+            userId={partnerProfile.uid}
+            username={partnerProfile.displayName}
           />
         </div>
       )}
@@ -105,4 +114,4 @@ const SpotifySection = () => {
   );
 };
 
-export default SpotifySection; 
+export default SpotifySection;


### PR DESCRIPTION
## Summary
- Avoid duplicate `useAuth` calls in `SpotifySection`
- Fetch partner profile once using `getPartnerProfile` and store in state

## Testing
- `npm run lint` (fails: 253 errors, 10 warnings)
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68996cff757c83289c3bec47267d627f